### PR TITLE
Add new or update profile on 'I know', remove skill on 'forget'

### DIFF
--- a/bin/botFunctions.js
+++ b/bin/botFunctions.js
@@ -251,7 +251,7 @@ function getMatchingProfiles(postBody, res) {
             .send(invalidRequest(postBody.user_name, 'missing requested skill.'));
     }
 
-    var parsedSkill  = parseSkill(postBody.postText),
+    var parsedSkill  = fetchSkill(postBody.postText),
         escapedSkill = escapeSkill(parsedSkill);
 
     // find documents where 'skill' in 'skills' and
@@ -259,7 +259,7 @@ function getMatchingProfiles(postBody, res) {
     Profiles
         .find({
             skills: {
-                $regex: new RegExp('^' + escapedSkill, 'i')
+                $regex: new RegExp('^' + escapedSkill + '$', 'i')
             },
             team_id: postBody.team_id
         })
@@ -319,7 +319,7 @@ function addProfile(postBody, res) {
                     // build updated, parsed, de-duplicated skills array
                     newSkills = buildSkills(newText);
 
-                console.log(newSkills);  // diag
+                // console.log(newSkills);  // diag
 
                 // update profile's properties
                 profile.postText = newText;

--- a/bin/botFunctions.js
+++ b/bin/botFunctions.js
@@ -43,7 +43,7 @@ function generateHelpResponse(you) {
                     }
                 ],
                 'mrkdwn_in': ['fields', 'text'],
-                'footer': `<https://whobot.herokuapp.com/ | whobot : v1.0.0> | <https://github.com/belcurv/whobot | GitHub>`
+                'footer': `<https://whobot.herokuapp.com/ | whobot : v1.1.0> | <https://github.com/belcurv/whobot | GitHub>`
             }
         ]
     };

--- a/bin/whobot.js
+++ b/bin/whobot.js
@@ -45,12 +45,19 @@ module.exports = function (req, res, next) {
             BotFunctions.iKnow(postBody, res);
             break;
 
+        
         case /^forget me/gi.test(postBody.postText):
             // delete user's profile from database
             postBody.postText = req.body.text.substring(9);
             BotFunctions.forgetMe(postBody, res);
             break;
 
+        case /^forget/gi.test(postBody.postText):
+            // delete specified skill from user's profile
+            postBody.postText = req.body.text.substring(7);
+            BotFunctions.forgetSkill(postBody, res);
+            break;
+            
         default:
             // default response: show commands
             BotFunctions.help(postBody.user_name, res);

--- a/public/js/footer.js
+++ b/public/js/footer.js
@@ -8,7 +8,7 @@ var WhobotFooter = (function ($) {
     
     var DOM      = {},
         app     = 'whobot',
-        version  = '1.0.0',
+        version  = '1.1.0',
         repo     = 'https://github.com/belcurv/whobot',
         peter    = 'https://github.com/peterjmartinson/',
         jay      = 'https://github.com/belcurv/',


### PR DESCRIPTION
Previously, `addProfile()` function would overwrite existing user profiles with Mongoose `Model.update()` and 'upsert'.
These changes:

1. modify the behavior of `addProfile()`.  Now, it _creates_ a user profile if it doesn't exist, or _updates_ an existing user's skills list with new skills:
`/whobot I know <skill>, <skill>` ... either creates or updates with new skills

2. add a switch case branch(`forgetSkill`) and corresponding function (`deleteSkill()`) to remove single skills from a user's profile:
`/whobot forget <skill>` ... removes specified skill